### PR TITLE
Trim unnecessary '/' for building oauth_callback

### DIFF
--- a/common/user.php
+++ b/common/user.php
@@ -12,7 +12,8 @@ function user_oauth() {
 		// get the request token
 		$reply = $cb->oauth_requestToken(array(
 			// 'oauth_callback' => 'http://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI']
-			'oauth_callback' => SERVER_NAME . $_SERVER['REQUEST_URI']
+			//	Trim the first slash
+			'oauth_callback' => SERVER_NAME . ltrim($_SERVER['REQUEST_URI'],'/')
 		));
 
 		// store the token


### PR DESCRIPTION
SERVER_NAME always ends with '/' while REQUEST_URI starts with '/'.
When building the oauth_callback, we need to remove the duplicated '/'.